### PR TITLE
feat(dock): slow down dock animation speed

### DIFF
--- a/config/macos/dock.sh
+++ b/config/macos/dock.sh
@@ -22,7 +22,7 @@ defaults write com.apple.dock static-only -bool false
 
 # アニメーション速度を速くする
 defaults write com.apple.dock autohide-delay -float 0.0
-defaults write com.apple.dock autohide-time-modifier -float 0.15
+defaults write com.apple.dock autohide-time-modifier -float 0.5
 
 # ゴミ箱を空にした時の警告を無効化
 defaults write com.apple.finder WarnOnEmptyTrash -bool false


### PR DESCRIPTION
## Summary
- Dockのアニメーション速度を遅く調整しました
- `autohide-time-modifier`を0.15秒から0.5秒に変更

## Test plan
- [ ] `bash config/macos/dock.sh`を実行してDockの設定が適用されることを確認
- [ ] Dockの表示・非表示アニメーションが遅くなったことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)