### PR TITLE
fix(zshrc): update user ID in mise path

### DIFF
--- a/root/.zshrc
+++ b/root/.zshrc
@@ -2,7 +2,7 @@
 export PATH="$HOME/.local/bin:$PATH"
 
 eval "$(sheldon source)"
-eval "$(/Users/itsuki/.local/bin/mise activate zsh)"
+eval "$(/Users/itsuki54/.local/bin/mise activate zsh)"
 eval "$(direnv hook zsh)"
 eval "$(starship init zsh)"
 eval "$(zoxide init zsh --hook prompt)"


### PR DESCRIPTION
## Summary
- .zshrcのmise activate pathのユーザーIDを`itsuki`から`itsuki54`に変更しました

## Test plan
- [ ] `source ~/.zshrc`を実行してエラーが出ないことを確認
- [ ] miseコマンドが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)