### PR TITLE
feat(brew): add Clipy clipboard manager

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
 brew "sheldon"
 
 cask "karabiner-elements"
+cask "clipy"
 cask "whatsapp"
 cask "arc"
 cask "discord"


### PR DESCRIPTION
## Summary
- Added Clipy to Brewfile as requested in #14

## Test plan
- [ ] Run `brew bundle` to verify Clipy installs correctly
- [ ] Confirm Clipy appears in macOS menu bar after installation

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/code)