### PR TITLE
fix(readme): update repository path to match ghq structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,14 @@ My personal development environment configuration files.
 ## Quick Start
 
 ```bash
-git clone https://github.com/itsuki54/dotfiles.git ~/src/dotfiles
-cd ~/src/dotfiles
+# Using ghq (recommended)
+ghq get itsuki54/dotfiles
+cd $(ghq root)/github.com/itsuki54/dotfiles
+./install.sh
+
+# Or manual clone
+git clone https://github.com/itsuki54/dotfiles.git ~/src/github.com/itsuki54/dotfiles
+cd ~/src/github.com/itsuki54/dotfiles
 ./install.sh
 ```
 


### PR DESCRIPTION
## Summary
- Updated README to reflect proper ghq directory structure
- Added both ghq and manual clone instructions
- Path now correctly shows `~/src/github.com/itsuki54/dotfiles`

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)