### PR TITLE
fix(starship): git repoパス表示の修正

### DIFF
--- a/config/.config/starship.toml
+++ b/config/.config/starship.toml
@@ -11,7 +11,7 @@ $character"""
 [custom.git_repo]
 when = true
 require_repo = true
-command = 'git rev-parse --show-toplevel | sed -e "s,$(ghq root)/\(github\.com/\)\?,,"'
+command = 'git rev-parse --show-toplevel | sed "s|$(ghq root)/github.com/||"'
 style = 'bold cyan'
 format = '[$output]($style) '
 


### PR DESCRIPTION
## Summary
- starship.tomlのcustom.git_repoコマンドで、sedの正規表現エスケープが正しく動作していなかった問題を修正
- フルパスが表示される代わりに、期待通り`owner/repo`形式で表示されるように修正

## 変更内容
- sedコマンドの構文を簡潔なパイプ区切り文字を使用する形式に変更
- 複雑な正規表現エスケープを削除し、より読みやすく確実な動作に

## Test plan
- [x] gitリポジトリ内で`starship prompt`を実行し、`itsuki54/dotfiles`と表示されることを確認
- [x] 正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)