### PR TITLE
feat(zsh): add gcr function for creating GitHub repos with ghq

### DIFF
--- a/root/.zshrc
+++ b/root/.zshrc
@@ -52,8 +52,8 @@ function gcr() {
   # ghqのパスを作成
   local repo_path="$(ghq root)/github.com/$github_user/$repo_name"
   
-  # GitHubにリポジトリ作成（デフォルトでREADMEとMITライセンス追加）
-  gh repo create "$repo_name" --add-readme --license mit "$@"
+  # GitHubにリポジトリ作成（デフォルトでプライベート、READMEとMITライセンス追加）
+  gh repo create "$repo_name" --private --add-readme --license mit "$@"
   
   # ghqでクローン
   ghq get "$github_user/$repo_name"


### PR DESCRIPTION
## Summary
- ghqを使用してGitHubリポジトリを作成する`gcr`関数を追加
- デフォルトでREADMEとMITライセンスを含むように設定
- リポジトリ作成後、自動的に作成されたディレクトリに移動

## Test plan
- [ ] `gcr test-repo --public`でパブリックリポジトリが作成される
- [ ] `gcr test-repo --private`でプライベートリポジトリが作成される
- [ ] 作成後、自動的にghq管理下のディレクトリに移動する

🤖 Generated with [Claude Code](https://claude.ai/code)