### PR TITLE
fix(lefthook): mise設定ファイルの変更検知を修正

### DIFF
--- a/.lefthook/post-merge/install-diff.sh
+++ b/.lefthook/post-merge/install-diff.sh
@@ -29,13 +29,19 @@ if echo "$CHANGED_FILES" | grep -q "^Brewfile$"; then
     fi
 fi
 
-# mise設定ファイルが変更された場合（プロジェクトルート）
-if echo "$CHANGED_FILES" | grep -qE "^(\.mise\.toml|\.tool-versions)$"; then
+# mise設定ファイルが変更された場合
+if echo "$CHANGED_FILES" | grep -qE "(^\.mise\.toml$|^\.tool-versions$|^config/.config/mise/config\.toml$)"; then
     echo "🔧 mise configuration changed. Updating tools..."
     
     if command -v mise &> /dev/null; then
+        # ホームディレクトリでmiseをインストール（グローバルツール用）
         cd ~
         mise install
+        # プロジェクトディレクトリでもmiseをインストール（プロジェクト固有ツール用）
+        cd "$DOTFILES_DIR"
+        if [ -f ".mise.toml" ] || [ -f ".tool-versions" ]; then
+            mise install
+        fi
     else
         echo "  ⚠️  mise not found. Skipping tool update."
     fi


### PR DESCRIPTION
## 概要
lefthookのinstall-diffスクリプトでmise設定ファイルの変更が正しく検知されない問題を修正しました。

## 問題
- `install-diff.sh`がプロジェクトルートの`.mise.toml`や`.tool-versions`のみを検知していた
- 実際のmise設定ファイルは`config/.config/mise/config.toml`に存在していた
- そのため、mise設定が変更されても`mise install`が実行されなかった

## 修正内容
- 正規表現を更新して`config/.config/mise/config.toml`の変更も検知するように修正
- プロジェクトディレクトリでも条件付きで`mise install`を実行するように改善

## テスト
- `lefthook run post-merge`を実行して動作確認済み
- mise設定ファイルの変更が正しく検知され、`mise install`が実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)