### PR TITLE
brew install個別実行を禁止

### DIFF
--- a/root/.zshrc
+++ b/root/.zshrc
@@ -113,3 +113,15 @@ setopt APPEND_HISTORY            # append to history file
 setopt HIST_NO_STORE             # Don't store history commands
 
 bindkey '^K' autosuggest-accept
+
+# brew installの個別実行を禁止
+brew() {
+  if [[ "$1" == "install" ]]; then
+    echo "エラー: 'brew install'は禁止されています。"
+    echo "代わりに'brew bundle'を使用してください。"
+    echo "Brewfileに追加してから'brew bundle'を実行してください。"
+    return 1
+  else
+    command brew "$@"
+  fi
+}


### PR DESCRIPTION
## 概要
- zshrcに`brew install`の個別実行を禁止する設定を追加
- `brew bundle`を使った管理を促すエラーメッセージを表示

## 変更内容
- `brew()`関数を追加して`brew install`コマンドをオーバーライド
- Brewfileを使った`brew bundle`での管理を推奨

## テスト
```bash
# brew installを実行すると
$ brew install tree
エラー: 'brew install'は禁止されています。
代わりに'brew bundle'を使用してください。
Brewfileに追加してから'brew bundle'を実行してください。

# 他のbrewコマンドは正常動作
$ brew search tree  # OK
$ brew info tree    # OK
```

🤖 Generated with [Claude Code](https://claude.ai/code)