### PR TITLE
feat(lazygit): lazygit設定ファイルを追加

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/jesseduffield/lazygit/master/schema/config.json
+
+git:
+  branchPrefix: "itsuki54/"
+  paging:
+    externalDiffCommand: "difft --color=always"
+  mainBranches:
+    - "main"
+    - "master"
+    - "develop"
+    - "dev"
+  parseEmoji: true
+
+gui:
+  nerdFontsVersion: "3"
+  border: "single"
+  authorColors:
+    "renovate[bot]": "#737994"
+  theme:
+    activeBorderColor:
+      - "#ca9ee6"
+      - bold
+    inactiveBorderColor:
+      - "#737994"
+    optionsTextColor:
+      - "#8caaee"
+    selectedLineBgColor:
+      - "#414559"
+    cherryPickedCommitBgColor:
+      - "#51576d"
+    cherryPickedCommitFgColor:
+      - "#ca9ee6"
+    unstagedChangesColor:
+      - "#e78284"
+    defaultFgColor:
+      - "#c6d0f5"
+    searchingActiveBorderColor:
+      - "#e5c890"
+
+os:
+  editPreset: "nvim-remote"
+
+confirmOnQuit: true
+quitOnTopLevelReturn: true
+
+customCommands:
+  - key: "<c-s>"
+    context: "global"
+    command: "gh repo view --web"
+    description: "GitHubでリポジトリを開く"
+  - key: "<c-r>"
+    command: "gh pr create --fill-first --web"
+    context: "global"
+    loadingText: "Creating pull request on GitHub"
+    description: "GitHubでPRを作成"


### PR DESCRIPTION
## 概要
lazygit設定ファイルを追加しました。

## 変更内容
- ブランチプレフィックスを `itsuki54/` に変更
- mainブランチに `dev` を追加
- カスタムコマンドの説明を日本語で追加
- `gh home` コマンドを `gh repo view --web` に変更（より明確な動作のため）

## 設定ファイルの主な機能
- ブランチプレフィックスの自動設定
- Catppuccin Macchiatoテーマのカラースキーム
- difftツールによる外部diff表示
- カスタムキーバインド:
  - `Ctrl+S`: GitHubでリポジトリを開く
  - `Ctrl+R`: GitHubでPRを作成

🤖 Generated with [Claude Code](https://claude.ai/code)