### PR TITLE
NeoTreeでgitignoreファイルを表示するように修正

### DIFF
--- a/config/.config/nvim/lua/plugins/neo-tree.lua
+++ b/config/.config/nvim/lua/plugins/neo-tree.lua
@@ -4,7 +4,7 @@ return {
     filesystem = {
       filtered_items = {
         hide_dotfiles = false,
-        hide_gitignored = true,
+        hide_gitignored = false,
         never_show = {
           ".git",
           ".DS_Store",


### PR DESCRIPTION
## Summary
- NeoTreeの設定で`hide_gitignored = false`に変更
- `.gitignore`ファイルや、gitignoreされているファイルがNeoTreeで表示されるように修正

## Test plan
- [ ] Neovimを起動してNeoTreeを開く
- [ ] `.gitignore`ファイルが表示されることを確認
- [ ] gitignoreされているファイル（例：`zzz/`ディレクトリ）が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)