### PR TITLE
feat(zshrc): npm publishとnpm loginのみ許可するように変更

### DIFF
--- a/root/.zshrc
+++ b/root/.zshrc
@@ -168,10 +168,15 @@ brew() {
   fi
 }
 
-# npmの使用を禁止し、pnpmを推奨
+# npmの使用を制限（publishとloginのみ許可）
 npm() {
-  echo "エラー: npmは禁止されています。代わりにpnpmを使用してください。"
-  return 1
+  if [[ "$1" == "publish" || "$1" == "login" ]]; then
+    command npm "$@"
+  else
+    echo "エラー: npmは禁止されています。代わりにpnpmを使用してください。"
+    echo "ただし、'npm publish'と'npm login'は許可されています。"
+    return 1
+  fi
 }
 
 # pipの使用を禁止し、uvを推奨


### PR DESCRIPTION
## 概要
npm の使用制限を緩和し、`npm publish` と `npm login` コマンドのみ実行可能にしました。

## 変更内容
- `.zshrc` の npm 関数を修正
- `npm publish` と `npm login` は許可
- それ以外の npm コマンドは引き続き制限（pnpm への誘導メッセージ表示）

## 背景
パッケージの公開には npm publish が必要なため、この2つのコマンドのみ例外的に許可する必要がありました。