### PR TITLE
feat(zsh): gwaddコマンドをwtに名称変更し、nurazon59/プレフィックスを自動付与

### DIFF
--- a/root/.zshrc
+++ b/root/.zshrc
@@ -24,13 +24,19 @@ alias bat='nocorrect bat'
 alias cat='bat --paging=never'
 alias tree='eza --icons --git --group-directories-first --tree --git-ignore'
 
-function gwadd() {
+function wt() {
   if [ -z "$1" ]; then
-    echo "Usage: gwadd <branch-name>"
+    echo "Usage: wt <branch-name>"
     return 1
   fi
 
-  branch="$1"
+  # nurazon59/プレフィックスを追加（すでに付いている場合は重複しない）
+  if [[ "$1" == nurazon59/* ]]; then
+    branch="$1"
+  else
+    branch="nurazon59/$1"
+  fi
+  
   dir="../${branch//\//-}"
 
   # すでに存在するブランチか確認


### PR DESCRIPTION
## Summary
- `gwadd`コマンドを`wt`に名称変更
- ブランチ名に自動的に`nurazon59/`プレフィックスを付与する機能を追加
- すでにプレフィックスがある場合は重複しないように処理

## Test plan
- [ ] `source ~/.zshrc`で設定を反映
- [ ] `wt feature/test`でnurazon59/feature/testブランチが作成されることを確認
- [ ] `wt nurazon59/test`でプレフィックスが重複しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)