### PR TITLE
nvim-cmpをblink.cmpにする

### DIFF
--- a/config/.config/nvim/lua/plugins/example.lua
+++ b/config/.config/nvim/lua/plugins/example.lua
@@ -30,14 +30,21 @@ return {
   -- disable trouble
   { "folke/trouble.nvim", enabled = false },
 
-  -- override nvim-cmp and add cmp-emoji
+  -- use blink.cmp instead of nvim-cmp
   {
-    "hrsh7th/nvim-cmp",
-    dependencies = { "hrsh7th/cmp-emoji" },
-    ---@param opts cmp.ConfigSchema
-    opts = function(_, opts)
-      table.insert(opts.sources, { name = "emoji" })
-    end,
+    "saghen/blink.cmp",
+    dependencies = { "rafamadriz/friendly-snippets" },
+    version = "v0.*",
+    opts = {
+      keymap = { preset = "default" },
+      appearance = {
+        use_nvim_cmp_as_default = true,
+        nerd_font_variant = "mono",
+      },
+      sources = {
+        default = { "lsp", "path", "snippets", "buffer" },
+      },
+    },
   },
 
   -- change some telescope options and a keymap to browse plugin files


### PR DESCRIPTION
## Summary
- nvim-cmpをblink.cmpに置き換えました
- より高速でモダンな補完エンジンに変更

## Changes
- `hrsh7th/nvim-cmp`を`saghen/blink.cmp`に置き換え
- 依存関係を`cmp-emoji`から`friendly-snippets`に変更
- デフォルトのキーマップと外観設定を追加

## Test plan
- [ ] Neovimを起動して補完が正常に動作することを確認
- [ ] LSP補完、パス補完、スニペット、バッファ補完が機能することを確認

Closes #126

🤖 Generated with [Claude Code](https://claude.ai/code)