### PR TITLE
fix(aerospace): アプリの自動ワークスペース割り当てを無効化

### DIFF
--- a/config/.config/aerospace/aerospace.toml
+++ b/config/.config/aerospace/aerospace.toml
@@ -177,10 +177,10 @@ alt-shift-l = ['join-with right', 'mode main']
 3 = 3
 
 # Application workspace assignments
-[[on-window-detected]]
-if.app-id = 'company.thebrowser.Browser'
-run = 'move-node-to-workspace 2'
+# [[on-window-detected]]
+# if.app-id = 'company.thebrowser.Browser'
+# run = 'move-node-to-workspace 2'
 
-[[on-window-detected]]
-if.app-id = 'net.kovidgoyal.kitty'
-run = 'move-node-to-workspace 1'
+# [[on-window-detected]]
+# if.app-id = 'net.kovidgoyal.kitty'
+# run = 'move-node-to-workspace 1'


### PR DESCRIPTION
## 概要
AeroSpaceでアプリの自動ワークスペース割り当て設定が原因でウィンドウが重なる問題を修正しました。

## 変更内容
- Arc Browserとkittyの自動ワークスペース割り当て設定をコメントアウト
- 新しいウィンドウは現在のワークスペースで開くように変更

## 問題の原因
- アプリの自動割り当てと複数モニター設定の組み合わせで、ウィンドウのレイアウトが正しく処理されない場合があった
- AeroSpaceの内部状態が不整合になり、ウィンドウが重なって表示される問題が発生

## テスト
- [x] AeroSpace設定の再読み込みが正常に動作することを確認
- [x] 新しいウィンドウが現在のワークスペースで開くことを確認
- [x] ウィンドウの重なりが解消されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)