### PR TITLE
feat(install): Kittyターミナルのインストール設定を追加

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,23 @@ echo "Installing tools with mise..."
 cd ~
 mise install
 
+echo "Setting up Kitty terminal..."
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS用のKittyインストール
+    if ! command -v kitty &> /dev/null; then
+        echo "  -> Installing Kitty with curl..."
+        curl -L https://sw.kovidgoyal.net/kitty/installer.sh | sh /dev/stdin
+        
+        # Create a symbolic link to run kitty from anywhere
+        ln -sf ~/Applications/kitty.app/Contents/MacOS/kitty ~/.local/bin/kitty
+        ln -sf ~/Applications/kitty.app/Contents/MacOS/kitten ~/.local/bin/kitten
+        
+        echo "  -> Kitty installed successfully"
+    else
+        echo "  -> Kitty is already installed"
+    fi
+fi
+
 echo "Setting up Docker Compose CLI plugin..."
 mkdir -p ~/.docker/cli-plugins
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
## Summary
- install.shにKittyターミナルのインストール設定を追加
- curlで公式インストーラーを使用したmacOS向けのインストール処理
- ~/.local/binへのシンボリックリンク作成でグローバルアクセス可能に

## Related Issue
Closes #133

## Test plan
- [ ] macOSでinstall.shを実行してKittyがインストールされることを確認
- [ ] 既にKittyがインストール済みの場合、スキップされることを確認
- [ ] kittyコマンドがターミナルから実行可能なことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)