### PR TITLE
fix(zshrc): ハードコードされたユーザーパスを動的に変更

### DIFF
--- a/root/.zshrc
+++ b/root/.zshrc
@@ -4,7 +4,7 @@ export PATH="$HOME/.local/share/mise/installs/tree-sitter/latest:$PATH"
 export PATH="/Library/TeX/texbin:$PATH"
 
 eval "$(sheldon source)"
-eval "$(/Users/itsuki54/.local/bin/mise activate zsh)"
+eval "$(${HOME}/.local/bin/mise activate zsh)"
 eval "$(direnv hook zsh)"
 eval "$(starship init zsh)"
 eval "$(zoxide init zsh --hook prompt)"


### PR DESCRIPTION
## Summary
- .zshrcファイルでハードコードされていた`/Users/itsuki54/`パスを`${HOME}/`に変更
- mise activateのパスを動的に取得するように修正

## Issue
Closes #132

## Test plan
- [ ] zshを再起動して、mise activateが正常に動作することを確認
- [ ] 他のユーザー環境でも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)