### PR TITLE
feat(gh-dash): OctoとDiffviewとの連携キーバインディングを追加

### DIFF
--- a/config/.config/gh-dash/config.yml
+++ b/config/.config/gh-dash/config.yml
@@ -64,7 +64,19 @@ defaults:
 keybindings:
   universal: []
   issues: []
-  prs: []
+  prs:
+    - key: d
+      command: |-
+        kitty @ launch --type=tab --tab-title="{{.RepoName}}#{{.PrNumber}}" --cwd={{.RepoPath}} sh -c '
+          gh pr checkout {{.PrNumber}} &&
+          nvim -c ":DiffviewOpen origin/$(gh pr status --json baseRefName -q .currentBranch.baseRefName)...{{.HeadRefName}}"
+        '
+    - key: C
+      command: |-
+        kitty @ launch --type=tab --tab-title="{{.RepoName}}#{{.PrNumber}}" --cwd={{.RepoPath}} sh -c '
+          gh pr checkout {{.PrNumber}} &&
+          nvim -c ":Octo pr edit {{.PrNumber}}"
+        '
   branches: []
 repoPaths:
   :owner/:repo: ~/src/github.com/:owner/:repo


### PR DESCRIPTION
## 概要
gh-dashからNeovimのOcto.nvimとdiffview.nvimを使用してPRレビューできるようにキーバインディングを追加しました。

## 変更内容
- `d`キー: diffview.nvimを使用してPRの差分を表示
- `C`キー: Octo.nvimを使用してPRの編集画面を開く

## 関連
- fixes #153
- 参考記事: https://www.ushmz.dev/note/430d8733-3405-4880-945a-bb09d27d580a

## テスト方法
1. gh-dashを起動
2. PRリストで`d`キーを押すとdiffviewが開くことを確認
3. PRリストで`C`キーを押すとOctoのPR編集画面が開くことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)