### PR TITLE
feat(gh): nvimをデフォルトエディタに設定

### DIFF
--- a/config/.config/gh/config.yml
+++ b/config/.config/gh/config.yml
@@ -3,7 +3,7 @@ version: 1
 # What protocol to use when performing git operations. Supported values: ssh, https
 git_protocol: https
 # What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
-editor:
+editor: nvim
 # When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
 prompt: enabled
 # A pager program to send command output to, e.g. "less". If blank, will refer to environment. Set the value to "cat" to disable the pager.


### PR DESCRIPTION
## 概要
GitHub CLIのデフォルトエディタをnvimに設定

## 変更内容
- `config/.config/gh/config.yml`のeditorフィールドにnvimを設定

🤖 Generated with [Claude Code](https://claude.ai/code)