### PR TITLE
feat(nvim): NeovimにTerraform LSPサポートを追加

### DIFF
--- a/config/.config/nvim/lua/plugins/terraform.lua
+++ b/config/.config/nvim/lua/plugins/terraform.lua
@@ -1,0 +1,22 @@
+return {
+  {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        terraformls = {
+          filetypes = { "terraform", "tf", "terraform-vars" },
+        },
+      },
+    },
+  },
+  {
+    "stevearc/conform.nvim",
+    opts = {
+      formatters_by_ft = {
+        terraform = { "terraform_fmt" },
+        tf = { "terraform_fmt" },
+        ["terraform-vars"] = { "terraform_fmt" },
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- NeovimにTerraform LSPサポートを追加
- terraform-lsによるコード補完とエラーチェック機能
- terraform_fmtによる自動フォーマット設定

## Changes
- `config/.config/nvim/lua/plugins/terraform.lua`を新規作成
  - nvim-lspconfigでterraformlsサーバーを設定
  - conform.nvimでterraform_fmtフォーマッターを設定
  - .tf, .terraform-varsファイルに対応

## Test plan
- [ ] Neovimでterraformファイルを開いて、LSPが正しく動作することを確認
- [ ] コード補完が機能することを確認
- [ ] フォーマット機能が動作することを確認

🤖 Generated with Claude Code